### PR TITLE
Fix script class names and remove BOMs

### DIFF
--- a/UF/Assets/GarageClickerHandler.cs
+++ b/UF/Assets/GarageClickerHandler.cs
@@ -1,18 +1,18 @@
-﻿using UnityEngine;
+using UnityEngine;
 using TMPro;
 using UnityEngine.EventSystems;
 
-public class GarageClickHandler : MonoBehaviour
+public class GarageClickerHandler : MonoBehaviour
 {
     public GameObject garagePopupPanel;
     public TMP_Text popupText;
 
     private static GameObject activePanel = null;
-    private ParkingGarageManager garageManager;
+    private GarageManager garageManager;
 
     private void Start()
     {
-        garageManager = GetComponent<ParkingGarageManager>();
+        garageManager = GetComponent<GarageManager>();
     }
 
     private void OnMouseDown()

--- a/UF/Assets/GarageManager.cs
+++ b/UF/Assets/GarageManager.cs
@@ -1,11 +1,11 @@
 using UnityEngine;
 
-public class ParkingGarageManager : MonoBehaviour
+public class GarageManager : MonoBehaviour
 {
     public int totalSpots = 100;
     private int availableSpots;
 
-    public bool isUserCheckedIn = false; // <-- NEW
+    public bool isUserCheckedIn = false;
 
     void Start()
     {

--- a/UF/Assets/TutorialInfo/Scripts/Editor/ReadmeEditor.cs
+++ b/UF/Assets/TutorialInfo/Scripts/Editor/ReadmeEditor.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor;

--- a/UF/Assets/TutorialInfo/Scripts/Readme.cs
+++ b/UF/Assets/TutorialInfo/Scripts/Readme.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using UnityEngine;
 
 public class Readme : ScriptableObject


### PR DESCRIPTION
## Summary
- match `GarageManager` class with its filename
- align `GarageClickerHandler` class to its filename
- remove UTF-8 BOMs from tutorial scripts

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6883ef8439b48326a43820ba41b8a2fc