### PR TITLE
Fix missing UI references for garages

### DIFF
--- a/UF/Assets/GarageClickerHandler.cs
+++ b/UF/Assets/GarageClickerHandler.cs
@@ -13,6 +13,16 @@ public class GarageClickerHandler : MonoBehaviour
     private void Start()
     {
         garageManager = GetComponent<GarageManager>();
+
+        if (garagePopupPanel == null)
+        {
+            garagePopupPanel = GameObject.Find("GaragePopupPanel");
+        }
+
+        if (popupText == null && garagePopupPanel != null)
+        {
+            popupText = garagePopupPanel.GetComponentInChildren<TMP_Text>();
+        }
     }
 
     private void OnMouseDown()


### PR DESCRIPTION
## Summary
- auto-assign GaragePopupPanel and popup text in `GarageClickerHandler`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883f62b82f88326a76dd284c65e4f7b