### PR TITLE
Enable live user location tracking on map

### DIFF
--- a/Gatorpark/ViewController.swift
+++ b/Gatorpark/ViewController.swift
@@ -179,6 +179,7 @@ class ViewController: UIViewController {
 
     private func setupLocationManager() {
         locationManager.delegate = self
+        locationManager.desiredAccuracy = kCLLocationAccuracyBest
         locationManager.requestWhenInUseAuthorization()
     }
 
@@ -315,6 +316,7 @@ extension ViewController: CLLocationManagerDelegate {
         case .authorizedAlways, .authorizedWhenInUse:
             print("✅ Location authorized")
             manager.startUpdatingLocation()
+            mapView.setUserTrackingMode(.follow, animated: true)
         case .denied, .restricted:
             print("❌ Location denied")
         case .notDetermined:
@@ -326,6 +328,10 @@ extension ViewController: CLLocationManagerDelegate {
 
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         guard let location = locations.last else { return }
+        let region = MKCoordinateRegion(center: location.coordinate,
+                                        latitudinalMeters: 500,
+                                        longitudinalMeters: 500)
+        mapView.setRegion(region, animated: true)
         print("📍 User location:", location.coordinate)
     }
 


### PR DESCRIPTION
## Summary
- configure location manager for best accuracy and request permission
- follow user location when authorized and center map on updates

## Testing
- `xcodebuild -list` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ace66331688326bbc0fdc579e55d4c