### PR TITLE
Set default Gainesville location for map

### DIFF
--- a/Gatorpark/ViewController.swift
+++ b/Gatorpark/ViewController.swift
@@ -26,6 +26,7 @@ class ViewController: UIViewController {
 
     // MARK: - Location
     private let locationManager = CLLocationManager()
+    private let defaultCoordinate = CLLocationCoordinate2D(latitude: 29.6151744, longitude: -82.3552497)
 
     // MARK: - Data
     var garages: [Garage] = []
@@ -101,14 +102,14 @@ class ViewController: UIViewController {
         }
 
         let region = MKCoordinateRegion(
-            center: CLLocationCoordinate2D(latitude: 29.6396, longitude: -82.3496),
+            center: defaultCoordinate,
             span: MKCoordinateSpan(latitudeDelta: 0.2, longitudeDelta: 0.2)
         )
         mapView.setRegion(region, animated: true)
 
         let boundaryPoints = [
             CLLocationCoordinate2D(latitude: 29.7050, longitude: -82.3900),
-            CLLocationCoordinate2D(latitude: 29.6400, longitude: -82.2950)
+            CLLocationCoordinate2D(latitude: 29.6000, longitude: -82.2950)
         ]
         let mapPoints = boundaryPoints.map { MKMapPoint($0) }
         let xs = mapPoints.map { $0.x }
@@ -127,7 +128,7 @@ class ViewController: UIViewController {
         )
 
         mapView.delegate = self
-        mapView.showsUserLocation = true
+        mapView.showsUserLocation = false
     }
 
     private func setupSearchBar() {
@@ -315,8 +316,10 @@ extension ViewController: CLLocationManagerDelegate {
         switch manager.authorizationStatus {
         case .authorizedAlways, .authorizedWhenInUse:
             print("✅ Location authorized")
-            manager.startUpdatingLocation()
-            mapView.setUserTrackingMode(.follow, animated: true)
+            let region = MKCoordinateRegion(center: defaultCoordinate,
+                                            latitudinalMeters: 500,
+                                            longitudinalMeters: 500)
+            mapView.setRegion(region, animated: true)
         case .denied, .restricted:
             print("❌ Location denied")
         case .notDetermined:
@@ -327,12 +330,11 @@ extension ViewController: CLLocationManagerDelegate {
     }
 
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        guard let location = locations.last else { return }
-        let region = MKCoordinateRegion(center: location.coordinate,
+        let region = MKCoordinateRegion(center: defaultCoordinate,
                                         latitudinalMeters: 500,
                                         longitudinalMeters: 500)
         mapView.setRegion(region, animated: true)
-        print("📍 User location:", location.coordinate)
+        print("📍 Using default location:", defaultCoordinate)
     }
 
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {


### PR DESCRIPTION
## Summary
- Default map coordinate set to 29.6151744, -82.3552497
- Updated location manager to always center on the default coordinate
- Expanded map boundaries and hid actual user location

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ace98e27808326b3ba0b3a823f214f