### PR TITLE
Allow map to stop recentering on user

### DIFF
--- a/Gatorpark/ViewController.swift
+++ b/Gatorpark/ViewController.swift
@@ -308,10 +308,13 @@ extension ViewController: CLLocationManagerDelegate {
 
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         guard let location = locations.last else { return }
-        let region = MKCoordinateRegion(center: location.coordinate,
-                                        latitudinalMeters: 500,
-                                        longitudinalMeters: 500)
-        mapView.setRegion(region, animated: true)
+        // Only recenter the map if we're actively following the user.
+        if mapView.userTrackingMode == .follow || mapView.userTrackingMode == .followWithHeading {
+            let region = MKCoordinateRegion(center: location.coordinate,
+                                            latitudinalMeters: 500,
+                                            longitudinalMeters: 500)
+            mapView.setRegion(region, animated: true)
+        }
         print("📍 User location:", location.coordinate)
     }
 


### PR DESCRIPTION
## Summary
- only re-center map when actively following user location to allow manual map movement

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68aced098404832687ce09bb21c6e466