### PR TITLE
Style search bar with white background and black text

### DIFF
--- a/Gatorpark/ViewController.swift
+++ b/Gatorpark/ViewController.swift
@@ -121,10 +121,17 @@ class ViewController: UIViewController {
 
         if #available(iOS 13.0, *) {
             let textField = searchBar.searchTextField
-            textField.backgroundColor = .systemBackground
+            textField.backgroundColor = .white
+            textField.textColor = .black
+            textField.tintColor = .black
             textField.layer.cornerRadius = 10
             textField.layer.masksToBounds = true
+            if let leftView = textField.leftView as? UIImageView {
+                leftView.tintColor = .black
+            }
         }
+
+        searchBar.tintColor = .black
 
         searchBar.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(searchBar)


### PR DESCRIPTION
## Summary
- Match the search bar to the app's white-and-black theme
- Set the search field and icons to white backgrounds with black accents

## Testing
- `xcodebuild -project Gatorpark.xcodeproj -scheme Gatorpark -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' build` (fails: command not found)
- `swift test` (fails: Could not find Package.swift in this directory or any of its parent directories.)

------
https://chatgpt.com/codex/tasks/task_e_68ad071933688326b180f3ea86a61b00