### PR TITLE
Add in-app privacy policy and terms screens

### DIFF
--- a/Gatorpark/AppInfoViewController.swift
+++ b/Gatorpark/AppInfoViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import SafariServices
 
 final class AppInfoViewController: UIViewController {
     override func viewDidLoad() {
@@ -23,10 +22,12 @@ final class AppInfoViewController: UIViewController {
         summaryLabel.numberOfLines = 0
         summaryLabel.font = UIFont.preferredFont(forTextStyle: .body)
 
-        let privacyButton = makeLinkButton(title: "Privacy Policy",
-                                           urlString: "https://gatorpark.example.com/privacy")
-        let termsButton = makeLinkButton(title: "Terms of Use",
-                                         urlString: "https://gatorpark.example.com/terms")
+        let privacyButton = makeNavigationButton(title: "Privacy Policy") { [weak self] in
+            self?.showDocument(PrivacyPolicyViewController())
+        }
+        let termsButton = makeNavigationButton(title: "Terms of Use") { [weak self] in
+            self?.showDocument(TermsOfUseViewController())
+        }
 
         let supportButton = UIButton(type: .system)
         supportButton.setTitle("Contact Support", for: .normal)
@@ -52,20 +53,27 @@ final class AppInfoViewController: UIViewController {
         ])
     }
 
-    private func makeLinkButton(title: String, urlString: String) -> UIButton {
+    private func makeNavigationButton(title: String, action: @escaping () -> Void) -> UIButton {
         let button = UIButton(type: .system)
         button.setTitle(title, for: .normal)
         button.contentHorizontalAlignment = .leading
-        button.addAction(UIAction { [weak self] _ in
-            guard let url = URL(string: urlString) else { return }
-            let safari = SFSafariViewController(url: url)
-            self?.present(safari, animated: true)
+        button.addAction(UIAction { _ in
+            action()
         }, for: .touchUpInside)
         return button
     }
 
+    private func showDocument(_ viewController: UIViewController) {
+        if let navigationController {
+            navigationController.pushViewController(viewController, animated: true)
+        } else {
+            let nav = UINavigationController(rootViewController: viewController)
+            present(nav, animated: true)
+        }
+    }
+
     @objc private func contactSupport() {
-        guard let url = URL(string: "mailto:support@gatorpark.example.com") else { return }
+        guard let url = URL(string: "mailto:hassantariq233@gmail.com") else { return }
         UIApplication.shared.open(url)
     }
 

--- a/Gatorpark/PrivacyPolicyViewController.swift
+++ b/Gatorpark/PrivacyPolicyViewController.swift
@@ -1,0 +1,55 @@
+import UIKit
+
+final class PrivacyPolicyViewController: UIViewController {
+    private let privacyText = """
+GatorPark Privacy Policy
+
+Last updated: June 5, 2024
+
+GatorPark values your privacy. This policy explains how we collect, use, and protect your information.
+
+Information We Collect
+• Location information to show nearby parking garages when you grant permission.
+• App usage data to help us improve performance and reliability.
+
+How We Use Information
+We use your information to provide core features like finding open garages, to troubleshoot issues, and to improve the app experience.
+
+Data Sharing
+We do not sell your personal information. We only share data with service providers who support app functionality and are bound to protect it.
+
+Your Choices
+You may revoke location permissions at any time from your device settings. You can also delete the app to remove local data stored on your device.
+
+Contact Us
+If you have any questions about this policy, email us at hassantariq233@gmail.com.
+"""
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Privacy Policy"
+        view.backgroundColor = .systemBackground
+        navigationItem.largeTitleDisplayMode = .never
+        configureTextView()
+    }
+
+    private func configureTextView() {
+        let textView = UITextView()
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.isEditable = false
+        textView.alwaysBounceVertical = true
+        textView.backgroundColor = .clear
+        textView.text = privacyText
+        textView.font = UIFont.preferredFont(forTextStyle: .body)
+        textView.textColor = .label
+        textView.textContainerInset = UIEdgeInsets(top: 24, left: 20, bottom: 24, right: 20)
+
+        view.addSubview(textView)
+        NSLayoutConstraint.activate([
+            textView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            textView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            textView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            textView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+}

--- a/Gatorpark/TermsOfUseViewController.swift
+++ b/Gatorpark/TermsOfUseViewController.swift
@@ -1,0 +1,57 @@
+import UIKit
+
+final class TermsOfUseViewController: UIViewController {
+    private let termsText = """
+GatorPark Terms of Use
+
+Last updated: June 5, 2024
+
+By using GatorPark you agree to the following terms.
+
+1. Acceptable Use
+You may use the app to locate parking garages for personal, non-commercial purposes. You agree not to misuse the service or interfere with its operation.
+
+2. Account Responsibilities
+You are responsible for maintaining the security of your device and any credentials associated with third-party services you connect to the app.
+
+3. Service Availability
+We strive to keep the app reliable, but availability is not guaranteed. Features may change or be discontinued without notice.
+
+4. Limitation of Liability
+GatorPark provides parking information as-is. We are not responsible for inaccurate garage data, parking tickets, or other damages arising from use of the app.
+
+5. Changes to These Terms
+We may update these terms from time to time. Continued use of the app after changes become effective constitutes acceptance of the revised terms.
+
+Contact Us
+If you have questions about these terms, email hassantariq233@gmail.com.
+"""
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Terms of Use"
+        view.backgroundColor = .systemBackground
+        navigationItem.largeTitleDisplayMode = .never
+        configureTextView()
+    }
+
+    private func configureTextView() {
+        let textView = UITextView()
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.isEditable = false
+        textView.alwaysBounceVertical = true
+        textView.backgroundColor = .clear
+        textView.text = termsText
+        textView.font = UIFont.preferredFont(forTextStyle: .body)
+        textView.textColor = .label
+        textView.textContainerInset = UIEdgeInsets(top: 24, left: 20, bottom: 24, right: 20)
+
+        view.addSubview(textView)
+        NSLayoutConstraint.activate([
+            textView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            textView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            textView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            textView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+}


### PR DESCRIPTION
## Summary
- add dedicated privacy policy and terms of use view controllers with in-app copy
- update the About screen to open the new documents and refresh the support email address

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7ce1ef6fc8326b9603acac3bce595